### PR TITLE
Eliminando shadow y rounded de logotipo

### DIFF
--- a/src/components/nav/NavBarExample.vue
+++ b/src/components/nav/NavBarExample.vue
@@ -3,7 +3,7 @@
         <nav class="container px-6 py-8 mx-auto md:flex md:justify-between md:items-center">
             <div class="flex items-center justify-between">
                 <router-link to="/">
-                    <img src="@/assets/sharedz_full_transparent.png" alt="Descripción de la imagen" class="h-10  rounded-full shadow-lg">
+                    <img src="@/assets/sharedz_full_transparent.png" alt="Descripción de la imagen" class="h-10">
                 </router-link>
                 <!-- Mobile menu button -->
                 <div @click="toggleNav" class="flex md:hidden">


### PR DESCRIPTION
Originalmente, el logotipo tenía sombra y la imagen estaba redondeada.
Se han eliminado estas características para mejorar la apariencia del logo.

**Antes**
![image](https://github.com/Masakuata/sharedzvue/assets/33274873/df2e84b8-871c-46a4-884c-fd3db78d0448)

**Después**
![image](https://github.com/Masakuata/sharedzvue/assets/33274873/eff7333c-275f-4a1f-b00a-6ba82f0576b5)
